### PR TITLE
Fish Together feature from the Discord

### DIFF
--- a/ServerPluginProject/build.gradle
+++ b/ServerPluginProject/build.gradle
@@ -19,6 +19,9 @@ repositories {
         name = "fancyplugins2.0.7"
         url = "https://repo.fancyplugins.de/releases"
     }
+    maven {
+        url 'https://maven.citizensnpcs.co/repo'
+    }
 
 
 }
@@ -27,6 +30,8 @@ dependencies {
 
     compileOnly "io.papermc.paper:paper-api:1.20.4-R0.1-SNAPSHOT"
     compileOnly("de.oliver:FancyNpcs:2.0.7")
+    implementation 'com.denizenscript:denizen:1.3.0-SNAPSHOT'
+    implementation 'net.citizensnpcs:citizens-main:2.0.33-SNAPSHOT'
 
 
 }

--- a/ServerPluginProject/src/main/java/net/trysomethingdev/trysomethingdevamazingplugin/TrySomethingDevAmazingPlugin.java
+++ b/ServerPluginProject/src/main/java/net/trysomethingdev/trysomethingdevamazingplugin/TrySomethingDevAmazingPlugin.java
@@ -1,9 +1,15 @@
 package net.trysomethingdev.trysomethingdevamazingplugin;
 
+import com.denizenscript.denizen.scripts.commands.BukkitCommandRegistry;
+import net.citizensnpcs.api.CitizensAPI;
+import net.citizensnpcs.api.trait.TraitInfo;
 import net.trysomethingdev.trysomethingdevamazingplugin.commands.TutorialCommands;
+import net.trysomethingdev.trysomethingdevamazingplugin.denizen.FishTogetherCommand;
+import net.trysomethingdev.trysomethingdevamazingplugin.denizen.FishTogetherTrait;
 import net.trysomethingdev.trysomethingdevamazingplugin.fishtogethermode.FishTogetherModeManager;
 import net.trysomethingdev.trysomethingdevamazingplugin.handlers.BlockBreakHandler;
 import net.trysomethingdev.trysomethingdevamazingplugin.handlers.ChestHandler;
+import net.trysomethingdev.trysomethingdevamazingplugin.handlers.NpcFishHandler;
 import net.trysomethingdev.trysomethingdevamazingplugin.minetogethermode.MineTogetherModeManager;
 import net.trysomethingdev.trysomethingdevamazingplugin.util.DelayedTask;
 import org.bukkit.Bukkit;
@@ -42,6 +48,13 @@ public final class TrySomethingDevAmazingPlugin extends JavaPlugin {
     @Override
     public void onEnable() {
         Bukkit.getLogger().info("Starting TrySomethingDev Pluggin");
+
+        //AresNote: Register trait with CitizensAPI
+        CitizensAPI.getTraitFactory().registerTrait(TraitInfo.create(FishTogetherTrait.class).withName("fishtogether"));
+
+        // AresNote: Register the command which needs com.denizenscript.denizencore.scripts.commands.AbstractCommand;
+        BukkitCommandRegistry.registerCommand(FishTogetherCommand.class);
+
         // Plugin startup logic
         //PUT YOUR MINECRAFT USERNAME HERE
         String yourMineCraftPlayerName = "TrySomethingDev";
@@ -57,6 +70,9 @@ public final class TrySomethingDevAmazingPlugin extends JavaPlugin {
 
         new ChestHandler(this,mineTogetherModeManager,fishTogetherModeManager);
         new BlockBreakHandler(this,mineTogetherModeManager,fishTogetherModeManager);
+
+        // AresNote: Registered it the old-fashioned way.
+        getServer().getPluginManager().registerEvents(new NpcFishHandler(), this);
 
         net.trysomethingdev.trysomethingdevamazingplugin.fishtogethermode.items.ItemManager.init(this);
         net.trysomethingdev.trysomethingdevamazingplugin.minetogethermode.items.ItemManager.init(this);

--- a/ServerPluginProject/src/main/java/net/trysomethingdev/trysomethingdevamazingplugin/denizen/FishTogetherCommand.java
+++ b/ServerPluginProject/src/main/java/net/trysomethingdev/trysomethingdevamazingplugin/denizen/FishTogetherCommand.java
@@ -1,0 +1,77 @@
+package net.trysomethingdev.trysomethingdevamazingplugin.denizen;
+
+import com.denizenscript.denizen.nms.interfaces.FishingHelper;
+import com.denizenscript.denizen.objects.LocationTag;
+import com.denizenscript.denizen.objects.NPCTag;
+import com.denizenscript.denizen.utilities.Utilities;
+import com.denizenscript.denizencore.exceptions.InvalidArgumentsException;
+import com.denizenscript.denizencore.objects.Argument;
+import com.denizenscript.denizencore.objects.core.ElementTag;
+import com.denizenscript.denizencore.scripts.ScriptEntry;
+import com.denizenscript.denizencore.scripts.commands.AbstractCommand;
+import com.denizenscript.denizencore.utilities.debugging.Debug;
+import org.bukkit.Material;
+import org.bukkit.inventory.ItemStack;
+
+public class FishTogetherCommand extends AbstractCommand {
+    public FishTogetherCommand() {
+        setName("fishtogether");
+        setSyntax("fishtogether [<location>] (catch:{none}/default/junk/treasure/fish) (stop) (chance:<#>)");
+        setRequiredArguments(1, 4);
+        isProcedural = false;
+    }
+
+    @Override
+    public void parseArgs(ScriptEntry scriptEntry) throws InvalidArgumentsException {
+        for (Argument arg : scriptEntry) {
+            if (!scriptEntry.hasObject("location")
+                    && arg.matchesArgumentType(LocationTag.class)) {
+                scriptEntry.addObject("location", arg.asType(LocationTag.class));
+            } else if (!scriptEntry.hasObject("catch")
+                    && arg.matchesPrefix("catch")
+                    && arg.matchesEnum(FishingHelper.CatchType.class)) {
+                scriptEntry.addObject("catch", arg.asElement());
+            } else if (!scriptEntry.hasObject("stop")
+                    && arg.matches("stop")) {
+                scriptEntry.addObject("stop", new ElementTag(true));
+            } else if (!scriptEntry.hasObject("percent")
+                    && arg.matchesPrefix("catchpercent", "percent", "chance", "c")
+                    && arg.matchesInteger()) {
+                scriptEntry.addObject("percent", arg.asElement());
+            }
+        }
+        if (!scriptEntry.hasObject("location") && !scriptEntry.hasObject("stop")) {
+            throw new InvalidArgumentsException("Must specify a valid location!");
+        }
+        scriptEntry.defaultObject("catch", new ElementTag("NONE"))
+                .defaultObject("stop", new ElementTag(false))
+                .defaultObject("percent", new ElementTag(65));
+        if (!Utilities.entryHasNPC(scriptEntry) || !Utilities.getEntryNPC(scriptEntry).isSpawned()) {
+            throw new InvalidArgumentsException("This command requires a linked and spawned NPC!");
+        }
+    }
+
+    @Override
+    public void execute(ScriptEntry scriptEntry) {
+        LocationTag location = scriptEntry.getObjectTag("location");
+        ElementTag catchtype = scriptEntry.getElement("catch");
+        ElementTag stop = scriptEntry.getElement("stop");
+        ElementTag percent = scriptEntry.getElement("percent");
+        if (scriptEntry.dbCallShouldDebug()) {
+            Debug.report(scriptEntry, getName(), location, catchtype, percent, stop);
+        }
+        NPCTag npc = Utilities.getEntryNPC(scriptEntry);
+
+        // AresNote: Created my own AresTrait to create the custom behavior
+        FishTogetherTrait trait = npc.getCitizen().getOrAddTrait(FishTogetherTrait.class);
+        if (stop.asBoolean()) {
+            trait.stopFishing();
+            return;
+        }
+
+        npc.getEquipmentTrait().set(0, new ItemStack(Material.FISHING_ROD));
+        trait.setCatchPercent(percent.asInt());
+        trait.setCatchType(FishingHelper.CatchType.valueOf(catchtype.asString().toUpperCase()));
+        trait.startFishing(location);
+    }
+}

--- a/ServerPluginProject/src/main/java/net/trysomethingdev/trysomethingdevamazingplugin/denizen/FishTogetherTrait.java
+++ b/ServerPluginProject/src/main/java/net/trysomethingdev/trysomethingdevamazingplugin/denizen/FishTogetherTrait.java
@@ -1,0 +1,364 @@
+package net.trysomethingdev.trysomethingdevamazingplugin.denizen;
+
+import com.denizenscript.denizen.nms.NMSHandler;
+import com.denizenscript.denizen.nms.interfaces.FishingHelper;
+import com.denizenscript.denizen.objects.NPCTag;
+import com.denizenscript.denizencore.utilities.CoreUtilities;
+import com.denizenscript.denizencore.utilities.debugging.Debug;
+import net.citizensnpcs.api.persistence.Persist;
+import net.citizensnpcs.api.trait.Trait;
+import net.citizensnpcs.util.PlayerAnimation;
+import net.kyori.adventure.text.Component;
+import net.trysomethingdev.trysomethingdevamazingplugin.events.NpcFishEvent;
+import org.bukkit.Bukkit;
+import org.bukkit.Location;
+import org.bukkit.Material;
+import org.bukkit.block.Block;
+import org.bukkit.block.BlockFace;
+import org.bukkit.entity.FishHook;
+import org.bukkit.entity.Item;
+import org.bukkit.entity.Player;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
+import org.bukkit.projectiles.ProjectileSource;
+import org.bukkit.util.Vector;
+
+public class FishTogetherTrait extends Trait {
+    public FishTogetherTrait() {
+        super("fishtogether");
+    }
+
+    @Persist("fishing")
+    public boolean fishing = false;
+    @Persist("catch type")
+    public FishingHelper.CatchType catchType = FishingHelper.CatchType.NONE;
+
+    @Persist("fishing spot")
+    public Location fishingLocation = null;
+
+    public FishHook fishHook = null;
+    public Item fish = null;
+
+    @Persist("catch chance")
+    public int catchPercent = 65;
+
+    @Persist("reel tick rate")
+    public int reelTickRate = 400;
+
+    @Persist("cast tick rate")
+    public int castTickRate = 75;
+
+    int reelCount = 100;
+    int castCount = 0;
+
+    public boolean isCast = false;
+
+    @Override
+    public void onSpawn() {
+        isCast = false;
+    }
+
+    @Override
+    public void run() {
+        if (fish != null) {
+            //AresNote: Changed npc.getStoredLocation()) < 3 to npc.getStoredLocation()) < 1
+            if (fish.getLocation().distance(npc.getStoredLocation()) < 1) {
+                try {
+                    fish.remove();
+                }
+                catch (Exception e) {
+                }
+            }
+        }
+        if (!fishing) {
+            isCast = false;
+            return;
+        }
+        if (isCast) {
+            reelCount++;
+            if (reelCount >= reelTickRate) {
+                reel();
+                reelCount = 0;
+                castCount = 0;
+            }
+        }
+        else {
+            castCount++;
+            if (castCount >= castTickRate) {
+                cast();
+                castCount = 0;
+            }
+        }
+    }
+
+    // <--[action]
+    // @Actions
+    // start fishing
+    //
+    // @Triggers when the NPC starts fishing. See also <@link command fish>.
+    //
+    // @Context
+    // None
+    //
+    // -->
+
+    /**
+     * Makes the NPC fish at the specified location
+     * <p/>
+     * TODO Reimplement variance, so each cast doesn't land in the exact same spot.
+     *
+     * @param location the location to fish at
+     */
+    public void startFishing(Location location) {
+        new NPCTag(npc).action("start fishing", null);
+        fishingLocation = location.clone();
+        cast();
+        fishing = true;
+    }
+
+    // <--[action]
+    // @Actions
+    // stop fishing
+    //
+    // @Triggers when the NPC stops fishing. See also <@link command fish>.
+    //
+    // @Context
+    // None
+    //
+    // -->
+
+    /**
+     * Makes the stop fishing.
+     */
+    public void stopFishing() {
+        new NPCTag(npc).action("stop fishing", null);
+        reelWithoutLoot();
+        reelCount = 100;
+        castCount = 0;
+        fishingLocation = null;
+        fishing = false;
+        npc.removeTrait(FishTogetherTrait.class);
+
+    }
+
+    public boolean scanForFishSpot(Location near, boolean horizontal) {
+        Block block = near.getBlock();
+        if (block.getType() == Material.WATER) {
+            fishingLocation = near.clone();
+            return true;
+        }
+        else if (block.getRelative(BlockFace.DOWN).getType() == Material.WATER) {
+            fishingLocation = near.clone().add(0, -1, 0);
+            return true;
+        }
+        else if (block.getRelative(BlockFace.DOWN).getRelative(BlockFace.DOWN).getType() == Material.WATER) {
+            fishingLocation = near.clone().add(0, -2, 0);
+            return true;
+        }
+        if (horizontal) {
+            return scanForFishSpot(near.clone().add(1, 0, 0), false)
+                    || scanForFishSpot(near.clone().add(-1, 0, 0), false)
+                    || scanForFishSpot(near.clone().add(0, 0, 1), false)
+                    || scanForFishSpot(near.clone().add(0, 0, -1), false);
+        }
+        return false;
+    }
+
+    public void startFishing() {
+        fishing = true;
+        Location search = npc.getStoredLocation().clone();
+        Vector direction = npc.getStoredLocation().getDirection().clone();
+        if (direction.getY() > -0.1) {
+            direction.setY(-0.1);
+        }
+        for (int i = 0; i < 10; i++) {
+            search.add(direction.clone());
+            if (scanForFishSpot(search, true)) {
+                break;
+            }
+        }
+    }
+
+    // <--[action]
+    // @Actions
+    // cast fishing rod
+    //
+    // @Triggers when the NPC casts a fishing rod. See also <@link command fish>.
+    //
+    // @Context
+    // None
+    //
+    // -->
+    private void cast() {
+        new NPCTag(npc).action("cast fishing rod", null);
+        if (fishingLocation == null || fishingLocation.getWorld() == null || !fishingLocation.getWorld().equals(npc.getEntity().getWorld())) {
+            Debug.echoError("Fishing location not found!");
+            return;
+        }
+        isCast = true;
+        double v = 34;
+        double g = 20;
+        Location from = npc.getStoredLocation();
+        from = from.add(0, 0.33, 0);
+        Location to = fishingLocation;
+        Vector test = to.clone().subtract(from).toVector();
+        double elev = test.getY();
+        Double testAngle = launchAngle(from, to, v, elev, g);
+        if (testAngle == null) {
+            return;
+        }
+        double hangtime = hangtime(testAngle, v, elev, g);
+        Vector victor = to.clone().subtract(from).toVector();
+        double dist = Math.sqrt(Math.pow(victor.getX(), 2) + Math.pow(victor.getZ(), 2));
+        elev = victor.getY();
+        if (dist == 0) {
+            return;
+        }
+        Double launchAngle = launchAngle(from, to, v, elev, g);
+        if (launchAngle == null) {
+            return;
+        }
+        victor.setY(Math.tan(launchAngle) * dist);
+        victor = normalizeVector(victor);
+        v += 0.5 * Math.pow(hangtime, 2);
+        v += (CoreUtilities.getRandom().nextDouble() - 0.8) / 2;
+        victor = victor.multiply(v / 20.0);
+
+        if (npc.getEntity() instanceof Player) {
+            fishHook = NMSHandler.fishingHelper.spawnHook(from, (Player) npc.getEntity());
+            fishHook.setShooter((ProjectileSource) npc.getEntity());
+            fishHook.setVelocity(victor);
+            PlayerAnimation.ARM_SWING.play((Player) npc.getEntity());
+        }
+    }
+
+    // <--[action]
+    // @Actions
+    // reel in fishing rod
+    //
+    // @Triggers when the NPC reels in its fishing rod. See also <@link command fish>.
+    //
+    // @Context
+    // None
+    //
+    // -->
+
+    private void reelWithoutLoot() {
+        isCast = false;
+        new NPCTag(npc).action("reel in fishing rod", null);
+        if (fishHook != null && fishHook.isValid()) {
+            fishHook.remove();
+            fishHook = null;
+        }
+        if (npc.getEntity() instanceof Player) {
+            PlayerAnimation.ARM_SWING.play((Player) npc.getEntity());
+        }
+    }
+
+
+    // <--[action]
+    // @Actions
+    // catch fish
+    //
+    // @Triggers when the NPC catches a fish. See also <@link command fish>.
+    //
+    // @Context
+    // None
+    //
+    // -->
+    private void reel() {
+        isCast = false;
+        new NPCTag(npc).action("reel in fishing rod", null);
+        int chance = (int) (Math.random() * 100);
+        if (catchPercent > chance && fishHook != null && catchType != FishingHelper.CatchType.NONE) {
+            try {
+                fish.remove();
+            }
+            catch (Exception e) {
+            }
+            Location location = fishHook.getLocation();
+
+            ItemStack diamond = new ItemStack(Material.DIAMOND_BLOCK);
+            ItemMeta diamondMeta = diamond.getItemMeta();
+            if (diamondMeta != null) {
+                Component displayName = Component.text("A RARE TREASURE");
+                diamondMeta.displayName(displayName);
+                diamond.setItemMeta(diamondMeta);
+            }
+
+            ItemStack result = NMSHandler.fishingHelper.getResult(fishHook, catchType);
+            if (result != null) {
+                //AresNote: Important: to use the diamond replace "result" with "diamond"
+                fish = location.getWorld().dropItem(location, result);
+                Location npcLocation = npc.getStoredLocation();
+                double d5 = npcLocation.getX() - location.getX();
+                double d6 = npcLocation.getY() - location.getY();
+                double d7 = npcLocation.getZ() - location.getZ();
+                double d8 = Math.sqrt(d5 * d5 + d6 * d6 + d7 * d7);
+                double d9 = 0.1D;
+                // AresNote: Increased velocity from 0.03D to 0.1D
+                fish.setVelocity(new Vector(d5 * d9, d6 * d9 + Math.sqrt(d8) * 0.1D, d7 * d9));
+
+                //AresNote: Create and fire custom event
+                NpcFishEvent npcFishEvent = new NpcFishEvent((Player) npc.getEntity(), fish);
+                Bukkit.getServer().getPluginManager().callEvent(npcFishEvent);
+            }
+            new NPCTag(npc).action("catch fish", null);
+        }
+        if (fishHook != null && fishHook.isValid()) {
+            fishHook.remove();
+            fishHook = null;
+        }
+        if (npc.getEntity() instanceof Player) {
+            PlayerAnimation.ARM_SWING.play((Player) npc.getEntity());
+        }
+    }
+
+    public boolean isFishing() {
+        return fishing;
+    }
+
+
+
+    public static Double launchAngle(Location from, Location to, double v, double elev, double g) {
+        Vector victor = from.clone().subtract(to).toVector();
+        double dist = Math.sqrt(Math.pow(victor.getX(), 2) + Math.pow(victor.getZ(), 2));
+        double v2 = Math.pow(v, 2);
+        double v4 = Math.pow(v, 4);
+        double derp = g * (g * Math.pow(dist, 2) + 2 * elev * v2);
+
+        if (v4 < derp) {
+            return null;
+        }
+        else {
+            return Math.atan((v2 - Math.sqrt(v4 - derp)) / (g * dist));
+        }
+    }
+
+    public static double hangtime(double launchAngle, double v, double elev, double g) {
+        double a = v * Math.sin(launchAngle);
+        double b = -2 * g * elev;
+
+        if (Math.pow(a, 2) + b < 0) {
+            return 0;
+        }
+
+        return (a + Math.sqrt(Math.pow(a, 2) + b)) / g;
+    }
+
+    public static Vector normalizeVector(Vector victor) {
+        double mag = Math.sqrt(Math.pow(victor.getX(), 2) + Math.pow(victor.getY(), 2) + Math.pow(victor.getZ(), 2));
+        if (mag != 0) {
+            return victor.multiply(1 / mag);
+        }
+        return victor.multiply(0);
+    }
+
+    public void setCatchType(FishingHelper.CatchType catchType) {
+        this.catchType = catchType;
+    }
+
+    public void setCatchPercent(int catchPercent) {
+        this.catchPercent = catchPercent;
+    }
+}

--- a/ServerPluginProject/src/main/java/net/trysomethingdev/trysomethingdevamazingplugin/events/NpcFishEvent.java
+++ b/ServerPluginProject/src/main/java/net/trysomethingdev/trysomethingdevamazingplugin/events/NpcFishEvent.java
@@ -1,0 +1,37 @@
+package net.trysomethingdev.trysomethingdevamazingplugin.events;
+
+import org.bukkit.entity.Item;
+import org.bukkit.entity.Player;
+import org.bukkit.event.Event;
+import org.bukkit.event.HandlerList;
+import org.jetbrains.annotations.NotNull;
+
+public class NpcFishEvent extends Event {
+
+    private static final HandlerList handlers = new HandlerList();
+    private final Player player;
+
+    private final Item caughtItem;
+
+    public NpcFishEvent(Player player, Item caughtItem) {
+        this.player = player;
+        this.caughtItem = caughtItem;
+    }
+
+    public Player getPlayer() {
+        return player;
+    }
+
+    public Item getCaughtItem() {
+        return caughtItem;
+    }
+
+    @Override
+    public @NotNull HandlerList getHandlers() {
+        return handlers;
+    }
+
+    public static HandlerList getHandlerList() {
+        return handlers;
+    }
+}

--- a/ServerPluginProject/src/main/java/net/trysomethingdev/trysomethingdevamazingplugin/handlers/NpcFishHandler.java
+++ b/ServerPluginProject/src/main/java/net/trysomethingdev/trysomethingdevamazingplugin/handlers/NpcFishHandler.java
@@ -1,0 +1,28 @@
+package net.trysomethingdev.trysomethingdevamazingplugin.handlers;
+
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.format.NamedTextColor;
+import net.trysomethingdev.trysomethingdevamazingplugin.events.NpcFishEvent;
+import org.bukkit.Bukkit;
+import org.bukkit.entity.Item;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+
+public class NpcFishHandler implements Listener {
+
+    @EventHandler
+    public void onNpcFish(final NpcFishEvent event) {
+        final Item caught = event.getCaughtItem();
+        Component playerName = Component.text(event.getPlayer().getName()).color(NamedTextColor.GREEN);
+        Component plainText = Component.text(" was luck and fished a ");
+        Component itemName = Component.text(caught.getName()).color(NamedTextColor.AQUA);
+
+        Component broadcastMessage = Component.text().append(playerName)
+                .append(plainText)
+                .append(itemName)
+                .build();
+
+        Bukkit.broadcast(broadcastMessage);
+    }
+
+}


### PR DESCRIPTION
This commit introduces the changes mentioned in the TrySomethingDev fish-together Discord channel. 

:sparkles: Created a new folder called "denizen" which contains the FishTogether custom command that replaces the "fish" command. So, rather than doing  `/ex` fish, you can now use `/ex fishtogether`

:sparkles: Introduced the FishTogetherTrait within the denizen folder to allow for custom loot in the future.

:sparkles: Introduced the NpcFishEvent. This is a custom event called from the FishTogetherTrait class.

:sparkles: Introduced the NpcFishHandler as an event listener for the NpcFishEvent.

:wrench: Updated the TrySomethingDevAmazingPlugin class (should rename?) to register the trait with the CitizensAPI, register a new type of command, and registered the event listener

:wrench: Updated build.gradle with a new repository and dependencies.



